### PR TITLE
Including .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/gauss* linguist-vendored=true


### PR DESCRIPTION
Github incorrectly categorizes this project as a C library.

The file .gitattributes is used to control the github language reporting system. Marking the gauss/legendre C library as "vendor" code forces github to recognize this repository as R code