### PR TITLE
Octavpred raises a more readable error

### DIFF
--- a/R/sads-methods.R
+++ b/R/sads-methods.R
@@ -441,7 +441,9 @@ setMethod("octavpred", signature(object="missing",sad="missing", rad="character"
               drad <- get(paste("d",rad,sep=""),mode="function")
               ab <- do.call(drad, c(list(x=1:S),coef,dots))*N
             }
-            Y = hist(ab, breaks=c(2^(min(oct)-2),n), plot=FALSE)
+            tryCatch({Y = hist(ab, breaks=c(2^(min(oct)-2),n), plot=FALSE)},
+                     error = function(cond) stop("Octaves do not span the entire range, try using a larger oct argument (maybe negative octaves?)")
+                     )
             res <- data.frame(octave = oct, upper = n, Freq = Y$count)
             if(preston) res <- prestonfy(res, ceiling(ab))
             new("octav", res)


### PR DESCRIPTION
The only error left on #86 is the one generated by code such as

```R
moths.gs <- fitgs(moths)
octavpred(moths, rad="gs", coef=as.list(coef(moths.gs)))
octavpred(rad="gs", coef=as.list(coef(moths.gs)), S=length(moths), N=sum(moths))
```

This PR introduces a friendlier error message for this condition.