### PR TITLE
Provides limits for likelihood regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vignettes/*.dvi
 testes/
 src/*.o
 src/*.so
+.*.swp

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -16,10 +16,10 @@ export(fitbs, fitgamma, fitgeom, fitgs, fitlnorm, fitls, fitmand, fitmzsm,
 ## General fitting and ploting  functions
 export(fitrad, fitsad, octav, octavpred, radpred, pprad, ppsad, qqrad, qqsad, rad)
 ## Accessory functions
-export(plotprofmle, pred.logser, dtrunc, ptrunc, qtrunc, rsad, updatesad, updaterad)
+export(plotprofmle, likelregions, pred.logser, dtrunc, ptrunc, qtrunc, rsad, updatesad, updaterad)
 ## Explicit classes and methods export
 exportClasses(rad, octav, fitsad, fitrad)
-exportMethods(plot, points, lines, octavpred, radpred, qqsad, qqrad, plotprofmle)
+exportMethods(plot, points, lines, octavpred, radpred, qqsad, qqrad, plotprofmle, likelregions)
 # Methods that override bbmle counterparts:
 exportMethods(show, nobs, AIC, AICc)
 ## IMPORTS ##

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@
 * Better starting values for fitting Weibull distributions
 * fitgeom, fitpoilog and fitnbinom now can get argument trunc=NULL to avoid zero-truncation (the default)
 * fitgeom uses default optimization method from mle2 instead of Brent's method, to avoid some overflow errors for large datasets (e.g. moths)
-* dmzsm now returns zero for all abundance larger than the community size J
+* dmzsm and dvolkov now returns zero for any abundance larger than the community size J. Accordingly, pzsm and pvolkov now return 1 for any q>J and lower.tail=TRUE and zero for lower.tail=FALSE.
 * fixes important bugs in AICc
 
 0.2.1 (2015-06-14)

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -38,23 +38,25 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
       y <- tmp[,1]^2/2
       x <- (tmp[,2][,i])
       interpolF = splinefun(x, y, method="monoH.FC")
-      x <- seq(min(x), max(x), lenght.out=nseg*length(x))
+      # Redo the x axis to increase the number of points in nseg times
+      l = nseg*length(x); a <- (max(x) - min(x))/(l-1)
+      x <- a * 1:l + min(x)-a
       y <- interpolF(x)
 
-      do.call(curve, c(list(expr=expression(interpolF(x)), n=nseg*length(x),xlab=vname[i], add=T),dots))
+      do.call(plot, c(list(x=x, y=y, xlab=vname[i]),dots))
       if(!is.null(ratio)){
-        l <- length(interpol$y)
-	  # Finds where the interpolation crosses the "y = ratio" line
-        change <- (interpol$y - ratio)[2:l] * (interpol$y - ratio)[1:(l-1)]
+        l <- length(y)
+	  # Finds where the ation crosses the "y = ratio" line
+        change <- (y - ratio)[2:l] * (y - ratio)[1:(l-1)]
         endpoints <- which(change < 0)
 		# Adds the borders, if any of them is lower than ratio
-		if(interpol$y[1] < ratio) endpoints <- c(1, endpoints)
-		if(interpol$y[l] < ratio) endpoints <- c(endpoints, l)
-        corr <- (interpol$x[2]-interpol$x[1])/2
+		if(y[1] < ratio) endpoints <- c(1, endpoints)
+		if(y[l] < ratio) endpoints <- c(endpoints, l)
+        corr <- (x[2]-x[1])/2
 		if(length(endpoints) > 0)
         for (j in 1:(length(endpoints)/2)) {
-          lower <-interpol$x[endpoints[(2*j)-1]]+corr
-          upper <- interpol$x[endpoints[2*j]]+corr
+          lower <-x[endpoints[(2*j)-1]]+corr
+          upper <-x[endpoints[2*j]]+corr
           lines(c(lower,upper ),c(ratio, ratio), col=col.line, lty=2)
 		  if(endpoints[(2*j-1)] != 1) # dont draw vertical lines at the borders
 	          lines(rep(lower,2), c(-1, ratio), col=col.line, lty=2)
@@ -62,6 +64,7 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
 			  lines(rep(upper,2), c(-1, ratio), col=col.line, lty=2)
         }
       }
+
     }
 })
 setMethod("plotprofmle", "mle2",

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -34,37 +34,19 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
   }
   for(i in parseq)
     {
-      tmp <- mleprof[i][[1]]
-      y <- tmp[,1]^2/2
-      x <- (tmp[,2][,i])
-      interpolF = splinefun(x, y, method="monoH.FC")
-      # Redo the x axis to increase the number of points in nseg times
-      l = nseg*length(x); a <- (max(x) - min(x))/(l-1)
-      x <- a * 1:l + min(x)-a
-      y <- interpolF(x)
+      prof <- internal.spline(mleprof, i, ratio)
 
-      do.call(plot, c(list(x=x, y=y, xlab=vname[i]),dots))
-      if(!is.null(ratio)){
-        l <- length(y)
-	  # Finds where the ation crosses the "y = ratio" line
-        change <- (y - ratio)[2:l] * (y - ratio)[1:(l-1)]
-        endpoints <- which(change < 0)
-		# Adds the borders, if any of them is lower than ratio
-		if(y[1] < ratio) endpoints <- c(1, endpoints)
-		if(y[l] < ratio) endpoints <- c(endpoints, l)
-        corr <- (x[2]-x[1])/2
-		if(length(endpoints) > 0)
-        for (j in 1:(length(endpoints)/2)) {
-          lower <-x[endpoints[(2*j)-1]]+corr
-          upper <-x[endpoints[2*j]]+corr
+      do.call(plot, c(list(x=prof$x, y=prof$y, xlab=vname[i]),dots))
+		if(length(prof$endpoints) > 0)
+        for (j in 1:(length(prof$endpoints)/2)) {
+          lower <-x[prof$endpoints[(2*j)-1]]+corr
+          upper <-x[prof$endpoints[2*j]]+corr
           lines(c(lower,upper ),c(ratio, ratio), col=col.line, lty=2)
-		  if(endpoints[(2*j-1)] != 1) # dont draw vertical lines at the borders
-	          lines(rep(lower,2), c(-1, ratio), col=col.line, lty=2)
-		  if(endpoints[(2*j)] != l) # dont draw vertical lines at the borders
-			  lines(rep(upper,2), c(-1, ratio), col=col.line, lty=2)
+          if(prof$endpoints[(2*j-1)] != 1) # dont draw vertical lines at the borders
+            lines(rep(lower,2), c(-1, ratio), col=col.line, lty=2)
+          if(prof$endpoints[(2*j)] != l) # dont draw vertical lines at the borders
+            lines(rep(upper,2), c(-1, ratio), col=col.line, lty=2)
         }
-      }
-
     }
 })
 setMethod("plotprofmle", "mle2",
@@ -73,3 +55,28 @@ setMethod("plotprofmle", "mle2",
     cat("in a different variable\n")
     plotprofmle(profile(object), ...)
 })
+
+internal.spline <- function(mleprof, i, ratio) {
+      tmp <- mleprof[i][[1]]
+      y <- tmp[,1]^2/2
+      x <- (tmp[,2][,i])
+      interpolF = splinefun(x, y, method="monoH.FC")
+      # Redo the x axis to increase the number of points in nseg times
+      l = nseg*length(x); a <- (max(x) - min(x))/(l-1)
+      x <- a * 1:l + min(x)-a
+      y <- interpolF(x)
+      lower <- c()
+      upper <- c()
+      if(!is.null(ratio)){
+        l <- length(y)
+        # Finds where the ation crosses the "y = ratio" line
+        change <- (y - ratio)[2:l] * (y - ratio)[1:(l-1)]
+        endpoints <- which(change < 0)
+        # Adds the borders, if any of them is lower than ratio
+        if(y[1] < ratio) endpoints <- c(1, endpoints)
+        if(y[l] < ratio) endpoints <- c(endpoints, l)
+        corr <- (x[2]-x[1])/2
+      }
+      return(list(x=x,y=y,endpoints=endpoints))
+}
+

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -32,22 +32,22 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
     oask <- devAskNewPage(TRUE)
     on.exit(devAskNewPage(oask))
   }
-  for(i in parseq)
-    {
-      prof <- internal.spline(mleprof, i, ratio)
-
-      do.call(plot, c(list(x=prof$x, y=prof$y, xlab=vname[i]),dots))
-		if(length(prof$endpoints) > 0)
-        for (j in 1:(length(prof$endpoints)/2)) {
-          lower <-x[prof$endpoints[(2*j)-1]]+corr
-          upper <-x[prof$endpoints[2*j]]+corr
-          lines(c(lower,upper ),c(ratio, ratio), col=col.line, lty=2)
-          if(prof$endpoints[(2*j-1)] != 1) # dont draw vertical lines at the borders
-            lines(rep(lower,2), c(-1, ratio), col=col.line, lty=2)
-          if(prof$endpoints[(2*j)] != l) # dont draw vertical lines at the borders
-            lines(rep(upper,2), c(-1, ratio), col=col.line, lty=2)
-        }
-    }
+  for(i in parseq) {
+    prof <- internal.spline(mleprof, i, ratio)
+    do.call(plot, c(list(x=prof$x, y=prof$y, xlab=vname[i]),dots))
+    L <- length(prof$lower) # Is the same as length(prof$upper)
+    if(L > 0)
+      for (j in 1:L) {
+        lines(c(prof$lower[j],prof$upper[j]),c(ratio, ratio), col=col.line, lty=2)
+        xx <- prof$x[1]/2 + prof$x[2]/2 + 1e-12
+        print(prof$lower[j])
+        print(xx)
+        if(prof$lower[j] > xx) # dont draw vertical lines at the borders
+          lines(rep(prof$lower[j],2), c(-1, ratio), col=col.line, lty=2)
+        if(prof$upper[i] < max(prof$x)) # dont draw vertical lines at the borders
+          lines(rep(prof$upper[j],2), c(-1, ratio), col=col.line, lty=2)
+      }
+  }
 })
 setMethod("plotprofmle", "mle2",
     function(object, ...) {
@@ -76,7 +76,11 @@ internal.spline <- function(mleprof, i, ratio) {
         if(y[1] < ratio) endpoints <- c(1, endpoints)
         if(y[l] < ratio) endpoints <- c(endpoints, l)
         corr <- (x[2]-x[1])/2
+        for (j in 1:(length(endpoints)/2)) {
+          lower <-c(lower, x[endpoints[(2*j)-1]]+corr)
+          upper <-c(upper, x[endpoints[2*j]]+corr)
+        }
       }
-      return(list(x=x,y=y,endpoints=endpoints))
+      return(list(x=x,y=y,lower=lower, upper=upper))
 }
 

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -40,8 +40,6 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
       for (j in 1:L) {
         lines(c(prof$lower[j],prof$upper[j]),c(ratio, ratio), col=col.line, lty=2)
         xx <- prof$x[1]/2 + prof$x[2]/2 + 1e-12
-        print(prof$lower[j])
-        print(xx)
         if(prof$lower[j] > xx) # dont draw vertical lines at the borders
           lines(rep(prof$lower[j],2), c(-1, ratio), col=col.line, lty=2)
         if(prof$upper[i] < max(prof$x)) # dont draw vertical lines at the borders
@@ -84,3 +82,34 @@ internal.spline <- function(mleprof, i, ratio) {
       return(list(x=x,y=y,lower=lower, upper=upper))
 }
 
+setGeneric("likelregions", 
+    def=function(object, nseg=20, ratio=log(8), which=NULL, ...) standardGeneric("likelregions")
+    )
+setMethod("likelregions", "profile.mle2",
+function(object, nseg, ratio, ...){
+  mleprof <- object@profile
+  npar <- length(mleprof)
+  if(missing(which))
+    which <- 1:npar
+  out <- list()
+  vname <- names(mleprof)
+  for(i in which) {
+    prof <- internal.spline(mleprof, i, ratio)
+    int <- list()
+    L <- length(prof$lower) # Is the same as length(prof$upper)
+    if(L > 0)
+      for (j in 1:L) {
+        # HOW DO I CONCATENATE THIS???
+        int <- c(int, c(prof$lower[j], prof$upper[j]))
+      }
+    out <- c(out, int)
+  }
+  # TODO: varnames and lower/upper names
+  out
+})
+setMethod("likelregions", "mle2",
+    function(object, ...) {
+    cat("NOTICE: Running a profile on the object. You should consider storing the profile\n")
+    cat("in a different variable\n")
+    likelregions(profile(object), ...)
+})

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -37,8 +37,11 @@ function(object, nseg, ratio, which, ask, col.line, varname, ...){
       tmp <- mleprof[i][[1]]
       y <- tmp[,1]^2/2
       x <- (tmp[,2][,i])
-      interpol = spline(x, y, n=nseg*length(x) )
-      do.call(plot, c(list(x=interpol,xlab=vname[i]),dots))
+      interpolF = splinefun(x, y, method="monoH.FC")
+      x <- seq(min(x), max(x), lenght.out=nseg*length(x))
+      y <- interpolF(x)
+
+      do.call(curve, c(list(expr=expression(interpolF(x)), n=nseg*length(x),xlab=vname[i], add=T),dots))
       if(!is.null(ratio)){
         l <- length(interpol$y)
 	  # Finds where the interpolation crosses the "y = ratio" line

--- a/R/plotprofmle.R
+++ b/R/plotprofmle.R
@@ -93,11 +93,15 @@ function(object, nseg, ratio, ...){
   out <- list()
   for(i in which) {
     prof <- internal.spline(mleprof, i, ratio, nseg)
+    xx <- prof$x[2]/2 + prof$x[2]/2 + 1e-12 # "minimum" x
+
     int <- list()
     L <- length(prof$lower) # Is the same as length(prof$upper)
     if(L > 0)
       for (j in 1:L) {
         int[[j]] <- c(prof$lower[j], prof$upper[j])
+        if(int[[j]][1] < xx) int[[j]][1] <- NA
+        if(int[[j]][2] > max(prof$x)) int[[j]][2] <- NA
       }
     out[[i]] <- int
   }

--- a/man/plotprofmle.Rd
+++ b/man/plotprofmle.Rd
@@ -36,8 +36,9 @@ plotprofmle(object, nseg=20, ratio=log(8), which=NULL, ask=NULL,
   }
 
   \item{ratio}{
-    real positive or NULL; log-likelihood ratio that defines the likelihood
-    interval to be shown in the plot.
+    real positive; log-likelihood ratio that defines the likelihood
+    interval to be shown in the plot, or set to \code{NULL} to suppress intervals
+    from being displayed.
   }
 
   \item{which}{

--- a/man/plotprofmle.Rd
+++ b/man/plotprofmle.Rd
@@ -3,24 +3,28 @@
 \alias{plotprofmle}
 \alias{plotprofmle,profile.mle2-method}
 \alias{plotprofmle,mle2-method}
-\alias{plotprofmle,mle-method}
+\alias{likelregions}
+\alias{likelregions,profile.mle2-method}
+\alias{likelregions,mle2-method}
 
-\title{Plot of log-likelihood profiles at original scale}
+\title{Log-likelihood profiles at original scale}
 
 \description{
   Given a likelihood profile of a model (object of the class \code{profile.mle}
-  or \code{profile.mle2}), plots the relative log-likelihood profiles and the
+  or \code{profile.mle2}), the function \code{plotprofmle} plots the relative log-likelihood profiles and the
   plausibility intervals for each one of the (or selected ones) parameters of a model.
+  These same plausibility regions might be returned by \code{likelregions}.
 }
 
 \section{Methods}{\describe{
-\item{code{signature(object="profile.mle2")}}{The preferred invocation for this method.}
+\item{code{signature(object="profile.mle2")}}{The preferred invocation for these methods.}
 \item{code{signature(object="mle2")}}{A convenience wrapper that calls \code{profile} on the mle2 object and runs the former method.}
 }}
 
 \usage{
 plotprofmle(object, nseg=20, ratio=log(8), which=NULL, ask=NULL, 
     col.line="blue", varname=NULL, \dots)
+likelregions(object, nseg=20, ratio=log(8), \dots)
 }
 
 \arguments{
@@ -37,7 +41,8 @@ plotprofmle(object, nseg=20, ratio=log(8), which=NULL, ask=NULL,
 
   \item{ratio}{
     real positive; log-likelihood ratio that defines the likelihood
-    interval to be shown in the plot, or set to \code{NULL} to suppress intervals
+    interval to be shown in the plot by \code{plotprofmle} or returned by 
+    \code{likelregions}. Set to \code{NULL} to suppress intervals
     from being displayed.
   }
 
@@ -81,9 +86,17 @@ plotprofmle(object, nseg=20, ratio=log(8), which=NULL, ask=NULL,
   values of the parameters resulting in a negative log-likelihood
   less or equal to a given value k are exp(k) times as plausible as
   the mle. Hence, exp(k) is a likelihood ratio, and delimits a plausibility interval (or likelihood
-  interval) for the mle's. Function \code{plotprofmle} plots profiles of the
+  interval) for the mle's. 
+  
+  Function \code{plotprofmle} plots profiles of the
   negative log-likelihood functions, along with the limits of
   likelihood interval for a given log-likelihood \code{ratio}.
+
+  Function \code{likelregions} returns the limits of the likelihood intervals for each parameter.
+  This might be seen as an analog function for \code{confint}, and will return very similar values
+  for corresponding ratios if the profile is symmetric and monotonic. However, if the profile is
+  ill-behaved, \code{likelregions} might return more than one interval for each parameter, whereas
+  \code{confint} will return \code{NA} with a warning.
 }
 
 \references{
@@ -109,6 +122,9 @@ birds.pln.p <- profile(birds.pln)
 par(mfrow=c(1,2))
 plotprofmle(birds.pln.p)
 par(mfrow=c(1,1))
+likelregions(birds.pln.p)
+# Compare with the confidence intervals
+confint(birds.pln.p)
 }
 
 \author{


### PR DESCRIPTION
This PR separates the internal spline generation for plotprofmle in the function `internal.spline`. It also changes the spline method to `monoH.FC` to avoid spurious oscilations in ill-behaved profiles, and provides the `likelregions` function to return the likelihood intervals for the selected profile (compare with `confint`).