### PR TITLE
Fixing support for zipf, zipf-mandelbrodt and broken-stick

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.2.5 (TBR)
 * new functions for density, distribution and quantile function for the Pueyo's powerbend distribution
+* octav is now a S4 method, and octav plots have a new argument "mid=TRUE"
 
 0.2.4 (2015-11-02)
 * octavpred now accepts a 'preston' argument (as does 'octav')

--- a/R/dbs.R
+++ b/R/dbs.R
@@ -1,9 +1,10 @@
 dbs <- function(x, N, S, log = FALSE){
 	N[ !is.finite(N) | N <= 0] <- NaN
 	S[ !is.finite(S) | S <= 0] <- NaN
-  y <- N *( (1-x/N)^S/(x-N) - (1-(x-1)/N)^S/(x-1-N) )
-  y[ x == N ] <- N *( - (1-(N-1)/N)^S/(N-1-N) )
-
+        ## New formula for dbs? #115 ##
+        ##y <- N *( (1-x/N)^S/(x-N) - (1-(x-1)/N)^S/(x-1-N) )
+        ##y[ x == N ] <- N *( - (1-(N-1)/N)^S/(N-1-N) )
+        y <- (S-1)*(1-x/N)^(S-2)/N
 	if (any(is.nan(y))) warning ("NaNs produced")
 	y[ x < 0 | x > N] <- 0
 	if(log) return (log(y))

--- a/R/dbs.R
+++ b/R/dbs.R
@@ -3,7 +3,7 @@ dbs <- function(x, N, S, log = FALSE){
 	S[ !is.finite(S) | S <= 0] <- NaN
 	y <- (S-1)*(1-x/N)^(S-2)/N
 	if (any(is.nan(y))) warning ("NaNs produced")
-	y[ x < 1 | x > N] <- 0
+	y[ x < 0 | x > N] <- 0
 	if(log) return (log(y))
 	else return(y)
 }

--- a/R/dbs.R
+++ b/R/dbs.R
@@ -3,7 +3,7 @@ dbs <- function(x, N, S, log = FALSE){
 	S[ !is.finite(S) | S <= 0] <- NaN
 	y <- (S-1)*(1-x/N)^(S-2)/N
 	if (any(is.nan(y))) warning ("NaNs produced")
-	y[ x < 0 | x > N] <- 0
+	y[ x < 1 | x > N] <- 0
 	if(log) return (log(y))
 	else return(y)
 }

--- a/R/dbs.R
+++ b/R/dbs.R
@@ -1,7 +1,9 @@
 dbs <- function(x, N, S, log = FALSE){
 	N[ !is.finite(N) | N <= 0] <- NaN
 	S[ !is.finite(S) | S <= 0] <- NaN
-	y <- (S-1)*(1-x/N)^(S-2)/N
+  y <- N *( (1-x/N)^S/(x-N) - (1-(x-1)/N)^S/(x-1-N) )
+  y[ x == N ] <- N *( - (1-(N-1)/N)^S/(N-1-N) )
+
 	if (any(is.nan(y))) warning ("NaNs produced")
 	y[ x < 0 | x > N] <- 0
 	if(log) return (log(y))

--- a/R/dbs.R
+++ b/R/dbs.R
@@ -1,10 +1,7 @@
 dbs <- function(x, N, S, log = FALSE){
 	N[ !is.finite(N) | N <= 0] <- NaN
 	S[ !is.finite(S) | S <= 0] <- NaN
-        ## New formula for dbs? #115 ##
-        ##y <- N *( (1-x/N)^S/(x-N) - (1-(x-1)/N)^S/(x-1-N) )
-        ##y[ x == N ] <- N *( - (1-(N-1)/N)^S/(N-1-N) )
-        y <- (S-1)*(1-x/N)^(S-2)/N
+  y <- (S-1)*(1-x/N)^(S-2)/N
 	if (any(is.nan(y))) warning ("NaNs produced")
 	y[ x < 0 | x > N] <- 0
 	if(log) return (log(y))

--- a/R/dgs.R
+++ b/R/dgs.R
@@ -5,7 +5,7 @@ dgs <- function(x, k, S,  log = FALSE) {
 	y <- cf*k*(1-k)^(x-1)
 	if (any(is.nan(y))) warning ("NaNs produced")
 	if (any(!is.wholenumber(x))) warning("non integer values in x")
-	y[ ! is.wholenumber(x) | x < 1] <- 0
+	y[ ! is.wholenumber(x) | x < 1 | x > S] <- 0
 	if(!log) return(y)
 	else return(log(y))
 }

--- a/R/dmand.R
+++ b/R/dmand.R
@@ -5,7 +5,7 @@ dmand <- function (x, N, s, v, log = FALSE) {
 	lny <- - s * log(x+v) - log(sum(((1:N)+v)^(-s)))
 	if (any(is.nan(lny))) warning ("NaNs produced")
 	if (any(!is.wholenumber(x))) warning("non integer values in x")
-	lny[ ! is.wholenumber(x) | x < 1] <- -Inf
+	lny[ ! is.wholenumber(x) | x < 1 | x > N] <- -Inf
 	if (log) return(lny)
 	else return(exp(lny))
 }

--- a/R/dzipf.R
+++ b/R/dzipf.R
@@ -4,7 +4,7 @@ dzipf <- function(x, N, s, log = FALSE) {
 	y <- -s*log(x)-log(sum(1/(1:N)^s))
 	if (any(is.nan(y))) warning ("NaNs produced")
 	if (any(!is.wholenumber(x))) warning("non integer values in x")
-	y[ ! is.wholenumber(x) | x < 1 | x > N] <- 0
+	y[ ! is.wholenumber(x) | x < 1 | x > N] <- -Inf
 	if(log) return(y)
 	else return(exp(y))
 }

--- a/R/pbs.R
+++ b/R/pbs.R
@@ -1,10 +1,11 @@
 pbs <- function(q, N, S, lower.tail=TRUE, log.p = FALSE){
-	N[ !is.finite(N) | N <= 0] <- NaN
-	S[ !is.finite(S) | S <= 0] <- NaN
-	y <- 1 + N*(1-q/N)^S/(q-N)
-	y[q < 0] <- 0; y[q >= N] <- 1
-	if(!lower.tail) y <- 1 - y
-	if(log.p) y <- log(y)
-	if(any(is.nan(y))) warning("NaNs produced")
-	return(y)
+    N[ !is.finite(N) | N <= 0] <- NaN
+    S[ !is.finite(S) | S <= 0] <- NaN
+    y <- 1 + N*(1-q/N)^S/(q-N)
+    y[q < 0] <- 0; y[q >= N] <- 1
+    if(!lower.tail) y <- 1 - y
+    if(log.p) y <- log(y)
+    if(any(is.nan(y))) warning("NaNs produced")
+    return(y)
 }
+

--- a/R/pbs.R
+++ b/R/pbs.R
@@ -2,7 +2,7 @@ pbs <- function(q, N, S, lower.tail=TRUE, log.p = FALSE){
 	N[ !is.finite(N) | N <= 0] <- NaN
 	S[ !is.finite(S) | S <= 0] <- NaN
 	y <- 1 + N*(1-q/N)^S/(q-N)
-	y[q < 0] <- 0; y[q >= N] <- 1
+	y[q < 1] <- 0; y[q >= N] <- 1
 	if(!lower.tail) y <- 1 - y
 	if(log.p) y <- log(y)
 	if(any(is.nan(y))) warning("NaNs produced")

--- a/R/pbs.R
+++ b/R/pbs.R
@@ -2,7 +2,7 @@ pbs <- function(q, N, S, lower.tail=TRUE, log.p = FALSE){
 	N[ !is.finite(N) | N <= 0] <- NaN
 	S[ !is.finite(S) | S <= 0] <- NaN
 	y <- 1 + N*(1-q/N)^S/(q-N)
-	y[q < 1] <- 0; y[q >= N] <- 1
+	y[q < 0] <- 0; y[q >= N] <- 1
 	if(!lower.tail) y <- 1 - y
 	if(log.p) y <- log(y)
 	if(any(is.nan(y))) warning("NaNs produced")

--- a/R/pmand.R
+++ b/R/pmand.R
@@ -1,17 +1,18 @@
 pmand <- function (q, N, s, v, lower.tail = TRUE, log.p = FALSE){
-	N[ !is.finite(N) | N < 1 | !is.wholenumber(N) ] <- NaN
-	s[ !is.finite(s) | s <= 0] <- NaN
-	v[ !is.finite(v) | v < 0] <- NaN
-	y <- c()
-	for (i in 1:length(q)) {
-		if (is.nan(q[i])) y[i] <- NaN
-		else y[i] <- log(sum(1/((1:q[i])+v)^s)) - log(sum(1/((1:N)+v)^s))
-	}
+    N[ !is.finite(N) | N < 1 | !is.wholenumber(N) ] <- NaN
+    s[ !is.finite(s) | s <= 0] <- NaN
+    v[ !is.finite(v) | v < 0] <- NaN
+    y <- c()
+    for (i in 1:length(q)) {
+        if (is.nan(q[i])) y[i] <- NaN
+        else y[i] <- log(sum(1/((1:q[i])+v)^s)) - log(sum(1/((1:N)+v)^s))
+    }
     y <- exp(y)
-	if (any(!is.wholenumber(q))) warning("non integer values in q")
-	y[ ! is.wholenumber(q) | q < 1 ] <- 0
+    if (any(!is.wholenumber(q))) warning("non integer values in q")
+    y[ ! is.wholenumber(q) | q < 1 ] <- 0
+    y[q > N] <- 1
     if (!lower.tail) y <- 1 - y
     if (log.p) y <- log(y)
-	if (any(is.nan(y))) warning ("NaNs produced")
-  return(y)
+    if (any(is.nan(y))) warning ("NaNs produced")
+    return(y)
 }

--- a/R/pzipf.R
+++ b/R/pzipf.R
@@ -9,6 +9,7 @@ pzipf <- function(q, N, s, lower.tail = TRUE, log.p = FALSE){
 	y <- exp(y)
 	if (any(!is.wholenumber(q))) warning("non integer values in q")
 	y[ ! is.wholenumber(q) | q < 1 ] <- 0
+        y[q > N] <- 1
 	if(!lower.tail) y <- 1-y
 	if(log.p) y <- log(y)
 	if (any(is.nan(y))) warning ("NaNs produced")

--- a/R/qbs.R
+++ b/R/qbs.R
@@ -4,8 +4,9 @@ qbs<-function(p, N, S, lower.tail = TRUE, log.p = FALSE){
   if(log.p) p <- exp(p)
   if(!lower.tail) p <- 1-p
   ## Ugly: just to make qbs(1, ...) = N
-  p[p==1] <- 1+1e-12
+  ##p[p==1] <- 1+1e-12
+  ## seems not necessary anymore with ties="ordered"
   Y <- 1:N
   X <- pbs(Y, N=N, S=S)
-  approx(x=X, y=Y, xout=p, method="constant", rule=2)$y
+  approx(x=X, y=Y, xout=p, method="linear", rule=2, ties="ordered")$y
 }

--- a/R/qgs.R
+++ b/R/qgs.R
@@ -8,5 +8,5 @@ qgs<-function(p, k, S, lower.tail = TRUE, log.p = FALSE){
   p[p==1] <- 1+1e-12
   Y <- 1:S
   X <- pgs(Y, k=k, S=S)
-  approx(x=X, y=Y, xout=p, method="constant", rule=2)$y
+  approx(x=X, y=Y, xout=p, method="constant", rule=2, ties="ordered")$y
 }


### PR DESCRIPTION
Support of Zipf, Zipf-mandelbrodt and Broken-stick do not include zero abundances or zero-th rank. PDF and CDF functions fixed accordingly.