### PR TITLE
Tweaking fitgeom optimizer a bit

### DIFF
--- a/R/fitgeom.R
+++ b/R/fitgeom.R
@@ -9,12 +9,16 @@ fitgeom <- function(x, trunc = 0, start.value, ...){
   } else{
     phat <- start.value
   }
+  if(!"method" %in% names(dots)){
+    dots$method <- "Brent"
+    if(!"lower" %in% names(dots)) dots$lower=max(c(phat/10, 1e-8))
+    if(!"upper" %in% names(dots)) dots$upper=min(c(phat*10, 0.99))
+  }
   if (is.null(trunc)){
     LL <- function(prob) -sum(dgeom(x, prob, log = TRUE))
   } else{
     LL <- function(prob) -sum(dtrunc("geom", x = x, coef = prob, trunc = trunc, log = TRUE))
   }
-        ##result <- do.call("mle2", c(list(LL, start = list(prob = phat), data = list(x = x), method = "Brent", lower = 0, upper = 1), dots)) ## Brent method does not converge sometimes.
-        result <- do.call("mle2", c(list(LL, start = list(prob = phat), data = list(x = x)), dots))  
+  result <- do.call("mle2", c(list(LL, start = list(prob = phat), data = list(x = x)), dots))  
   new("fitsad", result, sad = "geom", distr = distr.depr, trunc = ifelse(is.null(trunc), NaN, trunc))
 }


### PR DESCRIPTION
Fixes #125 using a constrained guess around the analytical MLE and using Brent. 

I've tested it with some random data as well as all our datasets, and it performs well. This evades the original error, which I believe occurred because the lower/upper guess was originally at prob=0 and prob=1, as these guesses are now constrained betwen 1e-8 and 0.99. 